### PR TITLE
Added equal sign to readme for correct usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple downloader to  download images from kemono.party
 ### Cookie File
 only needed if you want to download favorite creators or posts  
   
-`--cookie PATH`  
+`--cookie=PATH`  
 cookie file, default is cookies.txt (value separate by whitespace)  
 syntax:  
 
@@ -17,55 +17,55 @@ syntax:
 you can get cookies easily by using Chrome extension [Get cookies.txt LOCALLY](https://chrome.google.com/webstore/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
 #### Windows
 Windows can detect the cookie file automatically(Not supported in no_cookies_detection version)  
-`--cookie-browser string`  
+`--cookie-browser=string`  
 which browser to use, default is chrome (supported: chrome, firefox, edge , opera, vivaldi)  
 
 ### Download Option
-`--link [<urls>]`  
+`--link=[<urls>]`  
 download link, separate by comma  
-`--creator [<service>:<id>]`  
+`--creator=[<service>:<id>]`  
 download creators, separate by comma  
-`--banner bool`  
+`--banner=bool`  
 download banner, default is false (kemono only)  
-`--fav-site string`  
+`--fav-site=string`  
 specify the website to get favorites from (kemono or coomer), separated by comma  
-`--fav-creator bool`  
+`--fav-creator=bool`  
 download favorite creator, default is false  
-`--fav-post bool`  
+`--fav-post=bool`  
 download favorite post, default is false
 
 ### Post Filter Option
-`--first int`  
+`--first=int`  
 download first n post    
-`--last int`  
+`--last=int`  
 download last n post  
-`--date YYYYMMDD`  
+`--date=YYYYMMDD`  
 download post on date  
-`--date-before YYYYMMDD`  
+`--date-before=YYYYMMDD`  
 download post before date  
-`--date-after YYYYMMDD`  
+`--date-after=YYYYMMDD`  
 download post after date  
-`--update YYYYMMDD`  
+`--update=YYYYMMDD`  
 download post updated on date  
-`--update-before YYYYMMDD`  
+`--update-before=YYYYMMDD`  
 download post updated before date  
-`--update-after YYYYMMDD`  
+`--update-after=YYYYMMDD`  
 download post updated after date
 
 ### Image Filter Option
-`--extension-only [<ext>]`  
+`--extension-only=[<ext>]`  
 download post with extension, separate by comma  
-`--extension-exclude [<ext>]`  
+`--extension-exclude=[<ext>]`  
 download post without extension, separate by comma  
-`--max-size string`  
+`--max-size=string`  
 download post with size less than max-size (e.g. 1 MB, 1KB, 1.5 gb, etc.)  
-`--min-size string`  
+`--min-size=string`  
 download post with size greater than min-size (e.g. 1 MB, 1KB, 1.5 gb, etc.)
 
 ### Downloader Option
-`--output PATH`  
+`--output=PATH`  
 output path  
-`--template <tags>`  
+`--template=<tags>`  
 The template for customizing download paths, where you can use the following keywords to specify different parts of the path:  
 - `<ks:service>`: creator service
 - `<ks:creator>`: creator name
@@ -78,36 +78,36 @@ The template for customizing download paths, where you can use the following key
 for example:  
 `[<ks:service>] <ks:creator>/<ks:post>/<ks:index>-<ks:filename><ks:extension>`  
 
-`--image-template <tags>`  
+`--image-template=<tags>`  
 The template for customizing image file, `--template` should be set first  
-`--video-template <tags>`  
+`--video-template=<tags>`  
 The template for customizing video file, `--template` should be set first  
-`--audio-template <tags>`  
+`--audio-template=<tags>`  
 The template for customizing audio file, `--template` should be set first  
-`--archive-template <tags>`  
+`--archive-template=<tags>`  
 The template for customizing archive file, `--template` should be set first  
 
-`--content bool`  
+`--content=bool`  
 download content, default is false  
-`--overwrite bool`  
+`--overwrite=bool`  
 overwrite existing file  
-`--async bool`  
+`--async=bool`  
 download posts asynchronously, may cause the file order is not the same as the post order, can be used with --with-prefix-number, default false  
-`--max-download-parallel int`  
+`--max-download-parallel=int`  
 max download file concurrent, default is 3, async mode only  
-`--with-prefix-number bool`  
+`--with-prefix-number=bool`  
 add prefix number to file name `<order>_<filename>`, default false  
-`--name-rule-only-index bool`  
+`--name-rule-only-index=bool`  
 only use index as file name, default false  
-`--download-timeout int`  
+`--download-timeout=int`  
 download timeout in seconds, default 1800  
-`--retry int`  
+`--retry=int`  
 retry times, default 3  
-`--retry-interval number`  
+`--retry-interval=number`  
 retry interval in seconds, default 10. The number can be specified as either an int or float type  
-`--rate-limit int`  
+`--rate-limit=int`  
 rate limit in request/s, default 2  
-`--proxy string`  
+`--proxy=string`  
 proxy url, default is empty, support socks5, http, https (e.g. socks5://proxy:1080)
 
 ## Config File


### PR DESCRIPTION
The arguments should be supplied with an equal sign, as it can lead to unwanted behaviour if omitted