### PR TITLE
Support building with macOS

### DIFF
--- a/main/cookies_unix.go
+++ b/main/cookies_unix.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || darwin
 
 package main
 


### PR DESCRIPTION
Before the change, it won't build under macOS because `getCookies` is not defined for this platform (darwin):

```bash
$ go build
# github.com/elvis972602/kemono-scraper/main
./main.go:131:10: undefined: getCookies
```

It builds after the one-line change:

```bash
$ go build
```

And it works:

```bash
❯ ./main --fav-site=kemono --cookie=cookie.txt --fav-post
2024/01/15 00:42:48 load cookie from cookie.txt
2024/01/15 00:42:48 fetching favorite posts from kemono.su
Downloading Kemono
fetching creator list...
Start download 3 creators
fetching post list page 0...
fetching post list page 1...
fetching post list page 2...
fetching post list page 3...
fetching post list page 4...
fetching post list page 5...
fetching post list page 6...
fetching post list page 7...
download post: ...
```

Tested with macOS 14.2.1 (23C71), go version go1.21.6 darwin/arm64

Pls kindly review :)