### PR TITLE
added --page flag to limit the number of pages fetched on kemono 

### DIFF
--- a/kemono/fetch.go
+++ b/kemono/fetch.go
@@ -92,7 +92,7 @@ func (k *Kemono) FetchPosts(service, id string) (posts []Post, err error) {
 		return fmt.Errorf("fetch post list error: maximum retry count exceeded"), false
 	}
 
-	for i := 0; ; i++ {
+	for i := 0; i < k.pageLimit; i++ {
 		err, finish := fetch(i)
 		if err != nil {
 			return nil, err
@@ -100,8 +100,10 @@ func (k *Kemono) FetchPosts(service, id string) (posts []Post, err error) {
 		if finish {
 			break
 		}
+		
+		time.Sleep(2 * time.Second)
 	}
-	return
+	return posts, nil
 }
 
 // DownloadPosts download posts

--- a/kemono/kemono.go
+++ b/kemono/kemono.go
@@ -52,7 +52,7 @@ type Kemono struct {
 
 	// Creator filter
 	creatorFilters []CreatorFilter
-
+	pageLimit int // Add this field to store the page limit
 	// Post filter map[creator(<service>:<id>)][]PostFilter
 	postFilters map[string][]PostFilter
 
@@ -81,6 +81,7 @@ func NewKemono(options ...Option) *Kemono {
 		attachmentFilters: make(map[string][]AttachmentFilter),
 		retry:             3,
 		retryInterval:     5 * time.Second,
+		pageLimit:	   2,
 	}
 	for _, option := range options {
 		option(k)
@@ -160,6 +161,12 @@ func SetDownloader(downloader Downloader) Option {
 	return func(k *Kemono) {
 		k.Downloader = downloader
 	}
+}
+
+func SetPageLimit(limit int) Option {
+    return func(k *Kemono) {
+        k.pageLimit = limit // Assuming `pageLimit` is a field in your `Kemono` struct
+    }
 }
 
 // SetLog set log
@@ -251,7 +258,7 @@ func (k *Kemono) Start() error {
 	k.log.Printf("Start download %d creators", len(k.users))
 	for _, creator := range k.users {
 		// fetch posts
-		posts, err := k.FetchPosts(creator.Service, creator.Id)
+		posts, err := k.FetchPosts(creator.Service, creator.Id, )
 		if err != nil {
 			return err
 		}

--- a/main/main.go
+++ b/main/main.go
@@ -31,6 +31,7 @@ const (
 )
 
 var (
+	pageLimit = flag.Int("pages", 2, "Number of pages to fetch")
 	creators               []string
 	links                  []string
 	options                map[string][]kemono.Option
@@ -436,6 +437,7 @@ func main() {
 		}))
 		KemonoDownloader = downloader.NewDownloader(downloaderOptions...)
 		options[Kemono] = append(options[Kemono], kemono.SetDownloader(KemonoDownloader))
+		options[Kemono] = append(options[Kemono], kemono.SetPageLimit(*pageLimit))
 		KKemono = kemono.NewKemono(options[Kemono]...)
 	}
 	if len(options[Coomer]) > 0 {


### PR DESCRIPTION
## Fix: Prevent Endless Fetching and Add Page Limit Flag

### Problem
The existing code had two issues:
1. The program would endlessly fetch the creator list due to an unintended loop.
2. The requests were made too quickly, causing timeouts and overloading the server.

### Solution
- **Page Limit Flag**: Added a `--pages` flag to limit the number of pages fetched, preventing infinite loops.
- **Delay Between Requests**: Introduced a short delay between requests to avoid timeouts and comply with server rate limits.